### PR TITLE
Fix encoder

### DIFF
--- a/lib/node-plantuml.js
+++ b/lib/node-plantuml.js
@@ -39,7 +39,7 @@ PlantumlEncodeStream.prototype._transform = function (chunk, encoding, done) {
 
 PlantumlEncodeStream.prototype._flush = function (done) {
   var uml = Buffer.concat(this.chunks).toString()
-  var encoded = plantumlEncoder.encodeSync(uml)
+  var encoded = plantumlEncoder.encode(uml)
   this.push(new Buffer(encoded + '\n'))
   done()
 }


### PR DESCRIPTION
plantumlEncoder deprecated the use of encodeSync, so it's better to use the correct version here.

The deprecation also caused the encoder to stop working.
