### PR TITLE
Fixed script problems where examples would not compile or run properly

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,12 +26,21 @@ npm install node-plantuml -g
 
 Diagrams can be created from source files.
 
+input-file
+```
+A -> B: Hello
+```
+
+generate-uml.js
 ```javascript
 var plantuml = require('node-plantuml');
 var fs = require('fs');
 
-var gen = plantuml.generate("input-file");
-gen.out.pipe(fs.createWriteStream("output-file.png");
+var gen = plantuml.generate("input-file", {}, cb=>{
+	console.log("Generation Complete")
+});
+
+gen.out.pipe(fs.createWriteStream("output-file.png"));
 ```
 
 If your application will be making multiple PlantUML requests, it might be a good idea to enable the usage of Nailgun.


### PR DESCRIPTION
plantuml.generate() was missing second non-null required parameter (options) and a callback
