### PR TITLE
plantuml v 1.2019.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "node-plantuml",
   "version": "0.8.1",
-  "plantumlVersion": "1.2018.14",
+  "plantumlVersion": "1.2019.6",
   "description": "A Node.js module and CLI for running PlantUML",
   "main": "index.js",
   "author": "Markus Hedvall <mackanhedvall@gmail.com>",


### PR DESCRIPTION
Hi,

PlantUML recently switched to V1.2019.6 adding some breaking changes to `!define` and `!definelong`. You can still use them but when calling you have to add `()` method call (http://plantuml.com/preprocessing)

Considering they updated their server to use the new version there are going to be inconsistencies between diagrams generated online and ones generated locally.

I saw you have a script for downloading the .jar file right before publishing. I tested it out and it seems to download the latest version.

Great work btw !